### PR TITLE
Add basic equipment maintenance planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,15 @@
 <br>
 <img src="https://komarev.com/ghpvc/?username=rhuanbello&label=Visits">
 <img src="https://wakatime.com/badge/user/7c8afd8e-6490-43bb-b980-a081626d34af.svg">
+
+## Sistema de Planejamento de Manutenções
+
+Este repositório contém um exemplo simples de servidor Node.js que lê planilhas CSV para gerar um painel de futuras manutenções de equipamentos. O painel permite baixar eventos no formato iCalendar e o servidor emite lembretes no console para manutenções que ocorrerão em até 7 dias.
+
+### Como executar
+
+```
+node server.js
+```
+
+Acesse `http://localhost:3000` no navegador para visualizar o painel.

--- a/data/equipment.csv
+++ b/data/equipment.csv
@@ -1,0 +1,3 @@
+id,name,start_date,email
+1,Bomba,2024-01-01,jeferson@example.com
+2,Gerador,2025-09-05,responsavel@example.com

--- a/data/maintenance.csv
+++ b/data/maintenance.csv
@@ -1,0 +1,4 @@
+equipment_id,task,days_after_start
+1,Verificar pressão,30
+1,Trocar óleo,90
+2,Inspeção geral,10

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "maintenance-planner",
+  "version": "1.0.0",
+  "description": "Simple equipment maintenance planning web server.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8" />
+<title>Painel de Manutenções</title>
+</head>
+<body>
+<h1>Painel de Manutenções</h1>
+<table border="1" id="events">
+  <thead>
+    <tr><th>Equipamento</th><th>Tarefa</th><th>Data</th><th>Calendário</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
+<script>
+fetch('/events').then(r => r.json()).then(events => {
+  const tbody = document.querySelector('#events tbody');
+  events.forEach(ev => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${ev.equipment}</td><td>${ev.task}</td><td>${ev.date}</td><td><a href="/ics?id=${encodeURIComponent(ev.id)}">Salvar</a></td>`;
+    tbody.appendChild(tr);
+  });
+});
+</script>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,88 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+function parseCSV(filePath) {
+  const text = fs.readFileSync(filePath, 'utf-8').trim();
+  const lines = text.split(/\r?\n/);
+  const headers = lines[0].split(',');
+  return lines.slice(1).map(line => {
+    const values = line.split(',');
+    const obj = {};
+    headers.forEach((h, i) => obj[h] = values[i]);
+    return obj;
+  });
+}
+
+const equipment = parseCSV(path.join(__dirname, 'data', 'equipment.csv'));
+const maintenance = parseCSV(path.join(__dirname, 'data', 'maintenance.csv'));
+
+function buildEvents() {
+  const events = [];
+  equipment.forEach(eq => {
+    const eqMaint = maintenance.filter(m => m.equipment_id === eq.id);
+    eqMaint.forEach((m, idx) => {
+      const start = new Date(eq.start_date);
+      const date = new Date(start.getTime() + Number(m.days_after_start) * 24*60*60*1000);
+      const id = `${eq.id}-${idx}`;
+      events.push({
+        id,
+        equipment: eq.name,
+        email: eq.email,
+        task: m.task,
+        date: date.toISOString().slice(0,10)
+      });
+    });
+  });
+  return events;
+}
+
+let events = buildEvents();
+
+function sendReminders() {
+  const now = new Date();
+  const inSevenDays = new Date(now.getTime() + 7*24*60*60*1000);
+  events.forEach(ev => {
+    const evDate = new Date(ev.date);
+    if (evDate >= now && evDate <= inSevenDays) {
+      console.log(`Reminder: send email to ${ev.email} about ${ev.task} on ${ev.date}`);
+    }
+  });
+}
+
+setInterval(sendReminders, 24*60*60*1000); // daily
+sendReminders();
+
+function generateICS(event) {
+  const dtstart = event.date.replace(/-/g, '') + 'T090000Z';
+  return `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:${event.id}@planner\nDTSTAMP:${dtstart}\nDTSTART:${dtstart}\nSUMMARY:${event.equipment} - ${event.task}\nEND:VEVENT\nEND:VCALENDAR`;
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+  if (req.method === 'GET' && parsed.pathname === '/') {
+    const index = fs.readFileSync(path.join(__dirname, 'public', 'index.html')); 
+    res.writeHead(200, {'Content-Type': 'text/html'});
+    res.end(index);
+  } else if (req.method === 'GET' && parsed.pathname === '/events') {
+    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.end(JSON.stringify(events));
+  } else if (req.method === 'GET' && parsed.pathname === '/ics') {
+    const ev = events.find(e => e.id === parsed.query.id);
+    if (!ev) {
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+    res.writeHead(200, {'Content-Type': 'text/calendar'});
+    res.end(generateICS(ev));
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement simple Node.js server that reads maintenance data from CSV files
- display maintenance events in a web panel with calendar export
- log upcoming maintenance reminders

## Testing
- `node server.js` (server startup and reminder log)
- `curl -s http://localhost:3000/events`


------
https://chatgpt.com/codex/tasks/task_e_68c19a74fd00832cb1f0878e9656f579